### PR TITLE
Add Ability To Get Slice From Raw Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ text.
 * `End` - extract the traversal state, or report error
 * `ObjectKey` - pull an item out of a JSON Object, and make that the new state
 * `ArraySingleton` - select the only item in a 1 item JSON Array and make that the new state
+* `ArraySlice` - select a JSON array as a slice and make that the new state
 * `ArrayPredicate` - select an item from a JSON Array based on a predicate function and make that the new state
 * `Selector` - use a selector function to select whatever you want from the current state and make that the new state
 
@@ -40,6 +41,7 @@ your own components.
 * `GetInt32FromRawMessage`
 * `GetSliceFromRawMessage`
 * `GetMapFromRawMessage`
+* `GetMsgFromRawMessage`
 
 ## Example
 

--- a/example_test.go
+++ b/example_test.go
@@ -43,6 +43,14 @@ func ExampleTraversal_ArraySingleton() {
 	// Output: {"A":"a","B":43,"C":true}
 }
 
+func ExampleTraversal_ArraySlice() {
+	data, _ := json.Marshal([]testType{{A: "a", B: 43, C: true}})
+
+	tr.Start(data).ArraySlice().End(os.Stdout)
+
+	// Output: [{"A":"a","B":43,"C":true}]
+}
+
 func ExampleTraversal_ArrayPredicate() {
 	data, _ := json.Marshal([]testType{
 		{A: "a", B: 43, C: true},

--- a/raw_message.go
+++ b/raw_message.go
@@ -98,7 +98,7 @@ func GetSliceFromRawMessage(r json.RawMessage) ([]json.RawMessage, error) {
 	}
 	var m []json.RawMessage
 	if err = json.Unmarshal(b, &m); err != nil {
-		return nil, errors.Wrapf(err, "json.Unmarshal(%s failed: %s", b, err)
+		return nil, errors.Wrapf(err, "json.Unmarshal(%s) failed: %s", b, err)
 	}
 
 	return m, nil
@@ -128,6 +128,35 @@ func GetMapFromRawMessage(r json.RawMessage) (map[string]json.RawMessage, error)
 	var m map[string]json.RawMessage
 	if err = json.Unmarshal(b, &m); err != nil {
 		return nil, errors.Wrapf(err, "json.Unmarshal(%s failed: %s", b, err)
+	}
+
+	return m, nil
+}
+
+// GetRawMessage returns the json.RawMessage at next step of indention in a JSON structure
+// given:
+//
+// 		{
+//   		"a": "a1",
+//   		"b": "b1"
+// 		}
+//
+// expecting:
+//
+// 		[]json.RawMessage{
+//  		json.RawMessage{"a": "a1"},
+//    		json.RawMessage{"b": "b1"}
+// 		}
+//
+func GetMsgFromRawMessage(r json.RawMessage) (json.RawMessage, error) {
+	b, err := r.MarshalJSON()
+	if err != nil {
+		return nil, errors.Wrapf(err, "MarshalJSON(%s) failed: %s", r, err)
+	}
+
+	var m json.RawMessage
+	if err = json.Unmarshal(b, &m); err != nil {
+		return nil, errors.Wrapf(err, "json.Unmarshal(%s) failed %s", b, err)
 	}
 
 	return m, nil

--- a/raw_message.go
+++ b/raw_message.go
@@ -133,7 +133,7 @@ func GetMapFromRawMessage(r json.RawMessage) (map[string]json.RawMessage, error)
 	return m, nil
 }
 
-// GetRawMessage returns the json.RawMessage at next step of indention in a JSON structure
+// GetMsgFromRawMessage returns the json.RawMessage at next step of indention in a JSON structure
 // given:
 //
 // 		{

--- a/raw_message_test.go
+++ b/raw_message_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	tr "github.com/dougfort/traversal"
+	"github.com/pkg/errors"
 )
 
 func TestGetStringFromRawMessage(t *testing.T) {
@@ -102,5 +103,31 @@ func TestGetSliceFromRawMessage(t *testing.T) {
 	}
 	if string(result1) != "{\"b\": \"b1\"}" {
 		t.Fatalf("result1 = %s", result1)
+	}
+}
+
+func TestGetMsgFromRawMessage(t *testing.T) {
+	var err error
+	const testString = "test string"
+	testJSON := fmt.Sprintf("\"%s\"", testString)
+
+	var rawMessage json.RawMessage
+	err = rawMessage.UnmarshalJSON([]byte(testJSON))
+	if err != nil {
+		t.Fatalf("rawMessage.UnmarshalJSON() failed: %s", err)
+	}
+
+	result, err := tr.GetMsgFromRawMessage(rawMessage)
+	if err != nil {
+		t.Fatalf("GetStringFromRawMessage(%s) failed: %s", rawMessage, err)
+	}
+
+	var res string
+	err = json.Unmarshal(result, &res)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "failed to unmarshal msg from raw message"))
+	}
+	if res != testString {
+		t.Fatalf("expected '%s', got '%s", testString, result)
 	}
 }

--- a/traversal.go
+++ b/traversal.go
@@ -121,6 +121,44 @@ func (t *Traversal) ArraySingleton() *Traversal {
 	return &Traversal{err: nil, msg: s[0]}
 }
 
+// ArraySlice selects a whole slice from an Array in JSON
+// It will fail if the Array does not have any elemants
+//
+// given:
+//
+// 		[
+//			{"key": "value"}
+// 		]
+//
+// expecting
+//
+// 		[
+//			{"key": "value"}
+//		]
+//
+func (t *Traversal) ArraySlice() *Traversal {
+	if t.err != nil {
+		return t
+	}
+
+	s, err := GetMsgFromRawMessage(t.msg)
+	if err != nil {
+		return &Traversal{
+			err: errors.Wrap(err, "getSliceFromRawMessage"),
+			msg: nil,
+		}
+	}
+
+	if len(s) == 0 {
+		return &Traversal{
+			err: errors.Errorf("Array has %d, items", len(s)),
+			msg: nil,
+		}
+	}
+
+	return &Traversal{err: nil, msg: s}
+}
+
 // ArrayPredicate selects an entry from an Array based on a predicate
 //
 // given:

--- a/traversal.go
+++ b/traversal.go
@@ -1,4 +1,4 @@
-// package traversal for traversing JSON text
+// Package traversal for traversing JSON text
 package traversal
 
 import (
@@ -145,13 +145,6 @@ func (t *Traversal) ArraySlice() *Traversal {
 	if err != nil {
 		return &Traversal{
 			err: errors.Wrap(err, "getSliceFromRawMessage"),
-			msg: nil,
-		}
-	}
-
-	if len(s) == 0 {
-		return &Traversal{
-			err: errors.Errorf("Array has %d, items", len(s)),
 			msg: nil,
 		}
 	}

--- a/traversal_test.go
+++ b/traversal_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	tr "github.com/dougfort/traversal"
+	"github.com/pkg/errors"
 )
 
 func TestStartAndEnd(t *testing.T) {
@@ -126,6 +127,39 @@ func TestArrayPredicate(t *testing.T) {
 	err = tr.Start([]byte("[]")).ArrayPredicate(predicate).End(&buffer)
 	if err == nil {
 		t.Fatal("expecting error for empty Array")
+	}
+}
+
+func TestArraySlice(t *testing.T) {
+	var err error
+	var buffer bytes.Buffer
+	data := `[
+		{"name": "tagging"},
+		{"name": "tag"}
+	]`
+
+	// valid key
+	err = tr.Start([]byte(data)).ArraySlice().End(&buffer)
+	if err != nil {
+		t.Fatalf("error from valid JSON: %s", err)
+	}
+
+	if buffer.String() != data {
+		t.Fatalf("expected: %s, received: %s", data, buffer.String())
+	}
+
+	// Test to see if we can unmarshal the bytes from ArraySlice() into a slice
+	type testJSON struct {
+		Name string `json:"name"`
+	}
+	var testArray []testJSON
+	err = json.Unmarshal(buffer.Bytes(), &testArray)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "failed to unmarshal msg from raw message"))
+	}
+
+	if len(testArray) == 0 {
+		t.Fatalf("expected length greater than 0 for testArray")
 	}
 }
 


### PR DESCRIPTION
This PR adds the ability to retrieve a raw slice from a `json.RawMessage`, assuming the last JSON object in the traversal is a JSON array. 